### PR TITLE
Update antihack.sqf

### DIFF
--- a/antihack/antihack.sqf
+++ b/antihack/antihack.sqf
@@ -2653,6 +2653,7 @@ _AH_Admin = _AH_Admin + ("
 		if (!isNull _ct && {player distance _ct < 10}) then {
 			if !(locked _ct) then {
 				if (_type in DZE_UnLockedStorage) then {
+					dayz_combination = _ct getVariable ['CharacterID', '0'];
 					_ct spawn player_lockVault;
 				};
 				if (_type in DZE_DoorsLocked) then {


### PR DESCRIPTION
Allows the admin to lock safes that are already unlocked which the admin doesn't have the code saved to character. This fixes an issue where there are two safes with different combos, the admin unlocks both using the admin tools, and then can not lock the first one that was unlocked.